### PR TITLE
fix gitignore to properly allow coverage.svg

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 /.bundle/
 /.yardoc
 /_yardoc/
-/coverage/
+/coverage/*
 !coverage/coverage.svg
 /doc/
 /pkg/


### PR DESCRIPTION
This should fix the failing coverage workflow.