### PR TITLE
Add XDC Network (50) and XDC Apothem testnet (51)

### DIFF
--- a/lib/x402/chains.rb
+++ b/lib/x402/chains.rb
@@ -133,6 +133,22 @@ module X402
       currency: USDC_NAMED_USDC,
     },
 
+    # --- XDC ---
+    "xdc" => {
+      chain_id: 50,
+      caip2: "eip155:50",
+      usdc_address: "0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1",
+      explorer_url: "https://xdcscan.com",
+      currency: USDC_NAMED_USDC_V2,
+    },
+    "xdc-testnet" => {
+      chain_id: 51,
+      caip2: "eip155:51",
+      usdc_address: "0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4",
+      explorer_url: "https://testnet.xdcscan.com",
+      currency: USDC_NAMED_USDC_V2,
+    },
+
     # --- Solana ---
     "solana" => {
       chain_id: 101,


### PR DESCRIPTION
Adds XDC Network mainnet and XDC Apothem testnet to the `CHAINS` registry (CAIP-2 mappings derive automatically via `transform_values`).

XDC is an EVM-compatible L1 (XDPoS) with **native Circle USDC** supporting EIP-3009. USDC values verified on-chain:

| network | chain_id | USDC | name/version |
|---|---|---|---|
| xdc | 50 | `0xfA2958CB79b0491CC627c1557F441eF849Ca8eb1` | USDC / 2 |
| xdc-testnet | 51 | `0xb5AB69F7bBada22B28e79C8FFAECe55eF1c771D4` | USDC / 2 |

`ruby -c` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Registry-only addition with no logic changes; incorrect USDC or EIP-712 currency metadata would only affect payments if those chain keys are used.
> 
> **Overview**
> Registers **XDC Network** (`xdc`, chain ID 50) and **XDC Apothem testnet** (`xdc-testnet`, chain ID 51) in the unified `CHAINS` hash in `lib/x402/chains.rb`.
> 
> Each entry sets CAIP-2 (`eip155:50` / `eip155:51`), Circle USDC contract addresses, block explorer URLs, and `USDC_NAMED_USDC_V2` for EIP-712 signing. No other files change; `CAIP2_MAPPING`, `supported_chains`, and USDC lookup helpers pick up the new networks automatically.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a925fb11094cd85072e42f4e93ce0f0293c56aeb. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->