### PR TITLE
Add Arbitrum One and Arbitrum Sepolia as built-in chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [1.2.0] - Unreleased
 
 ### Added
+- **Arbitrum support** - Arbitrum One (`arbitrum`) and Arbitrum Sepolia (`arbitrum-sepolia`) join the built-in chain registry with native USDC defaults, supported by the Coinbase CDP facilitator
 - **Bazaar discovery** - `x402_discovery` controller macro declares discovery metadata per action; the extension is attached to every v2 402 the gem renders, echoed by paying clients, and indexed by facilitator catalogs (PayAI, Coinbase CDP Bazaar)
 - **`X402::DiscoveryExtension.declare`** - Builds the `extensions.bazaar` wire shape, matching `@x402/extensions` `declareDiscoveryExtension` (query and body forms)
 - **Coinbase CDP facilitator auth** - Requests to `api.cdp.coinbase.com` carry the required Bearer JWT (ES256 and Ed25519 keys, no new dependencies). Credentials via `CDP_API_KEY_ID` / `CDP_API_KEY_SECRET` or `config.cdp_api_key_id` / `config.cdp_api_key_secret`

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Accept instant blockchain micropayments in your Rails applications using the [x402 payment protocol](https://www.x402.org/).
 
-Supports 18 networks including Base, Polygon, Avalanche, Sei, Solana, and more.
+Supports 20 networks including Base, Arbitrum, Polygon, Avalanche, Sei, Solana, and more.
 
 ## Features
 
@@ -168,10 +168,10 @@ X402.configure do |config|
   config.facilitator = ENV.fetch("X402_FACILITATOR_URL", "https://www.x402.org/facilitator")
 
   # Blockchain network (default: "base-sepolia")
-  # Built-in: base, base-sepolia, polygon, polygon-amoy, avalanche, avalanche-fuji,
-  #           sei, sei-testnet, iotex, peaq, xlayer, xlayer-testnet,
-  #           skale-base, skale-base-sepolia, kiteai, kiteai-testnet,
-  #           solana, solana-devnet
+  # Built-in: base, base-sepolia, arbitrum, arbitrum-sepolia, polygon, polygon-amoy,
+  #           avalanche, avalanche-fuji, sei, sei-testnet, iotex, peaq,
+  #           xlayer, xlayer-testnet, skale-base, skale-base-sepolia,
+  #           kiteai, kiteai-testnet, solana, solana-devnet
   config.chain = ENV.fetch("X402_CHAIN", "base-sepolia")
 
   # Payment token (default: "USDC")
@@ -204,30 +204,30 @@ You can register custom EVM chains and tokens beyond the built-in options.
 
 #### Register a Custom Chain
 
-Add support for any EVM-compatible chain beyond the 18 built-in networks:
+Add support for any EVM-compatible chain beyond the 20 built-in networks:
 
 ```ruby
 X402.configure do |config|
   config.wallet_address = ENV['X402_WALLET_ADDRESS']
 
-  # Register Arbitrum (not built-in)
+  # Register Optimism (not built-in)
   config.register_chain(
-    name: "arbitrum",
-    chain_id: 42161,
+    name: "optimism",
+    chain_id: 10,
     standard: "eip155"
   )
 
   # Register the token for that chain
   config.register_token(
-    chain: "arbitrum",
+    chain: "optimism",
     symbol: "USDC",
-    address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    address: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
     decimals: 6,
     name: "USD Coin",
     version: "2"
   )
 
-  config.chain = "arbitrum"
+  config.chain = "optimism"
   config.currency = "USDC"
 end
 ```
@@ -279,11 +279,11 @@ X402.configure do |config|
   config.wallet_address = ENV['X402_WALLET_ADDRESS']
 
   # Register a custom chain not included in the built-in list
-  config.register_chain(name: "arbitrum", chain_id: 42161, standard: "eip155")
+  config.register_chain(name: "optimism", chain_id: 10, standard: "eip155")
   config.register_token(
-    chain: "arbitrum",
+    chain: "optimism",
     symbol: "USDC",
-    address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+    address: "0x0b2C639c533813f4Aa9D7837CAf62653d097Ff85",
     decimals: 6,
     name: "USD Coin",
     version: "2"
@@ -291,8 +291,8 @@ X402.configure do |config|
 
   # Accept payments on multiple chains (built-in + custom)
   config.accept(chain: "base-sepolia", currency: "USDC")
-  config.accept(chain: "polygon-amoy", currency: "USDC")
-  config.accept(chain: "arbitrum", currency: "USDC")
+  config.accept(chain: "arbitrum-sepolia", currency: "USDC")
+  config.accept(chain: "optimism", currency: "USDC")
 end
 ```
 
@@ -302,7 +302,7 @@ When `config.accept()` is used, the 402 response will include all accepted payme
 {
   "accepts": [
     { "network": "eip155:84532", "asset": "0x036CbD53842c5426634e7929541eC2318f3dCF7e", ... },
-    { "network": "eip155:80002", "asset": "0x41E94Eb019C0762f9Bfcf9Fb1E58725BfB0e7582", ... }
+    { "network": "eip155:421614", "asset": "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d", ... }
   ]
 }
 ```
@@ -499,6 +499,8 @@ Any x402 facilitator works via `X402_FACILITATOR_URL` / `config.facilitator`. Au
 | x402.org (default) | `https://www.x402.org/facilitator` | none |
 | PayAI | `https://facilitator.payai.network` | none |
 | Coinbase CDP | `https://api.cdp.coinbase.com/platform/v2/x402` | Bearer JWT, built in |
+
+> **Note:** Not every facilitator settles every chain — check your facilitator's `/supported` endpoint. For example, Arbitrum One and Arbitrum Sepolia are supported by the Coinbase CDP facilitator, while the default x402.org facilitator covers testnets like Base Sepolia.
 
 ### Using Coinbase CDP
 

--- a/lib/generators/x402/install/templates/x402_initializer.rb
+++ b/lib/generators/x402/install/templates/x402_initializer.rb
@@ -13,7 +13,8 @@ X402.configure do |config|
   config.facilitator = ENV.fetch("X402_FACILITATOR_URL", "https://www.x402.org/facilitator")
 
   # Blockchain network to use
-  # Options: "base-sepolia" (testnet), "base" (mainnet), "avalanche-fuji" (testnet), "avalanche" (mainnet)
+  # Options: "base-sepolia" (testnet), "base" (mainnet), "arbitrum-sepolia" (testnet),
+  #          "arbitrum" (mainnet), "avalanche-fuji" (testnet), "avalanche" (mainnet)
   # For testing, use "base-sepolia". For production, use "base" (no fees!)
   config.chain = ENV.fetch("X402_CHAIN", "base-sepolia")
 

--- a/lib/x402/chains.rb
+++ b/lib/x402/chains.rb
@@ -28,6 +28,22 @@ module X402
       currency: USDC_NAMED_USDC_V2,
     },
 
+    # --- Arbitrum ---
+    "arbitrum" => {
+      chain_id: 42161,
+      caip2: "eip155:42161",
+      usdc_address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+      explorer_url: "https://arbiscan.io",
+      currency: USDC_NAMED_USD_COIN_V2,
+    },
+    "arbitrum-sepolia" => {
+      chain_id: 421614,
+      caip2: "eip155:421614",
+      usdc_address: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+      explorer_url: "https://sepolia.arbiscan.io",
+      currency: USDC_NAMED_USD_COIN_V2,
+    },
+
     # --- Polygon ---
     "polygon" => {
       chain_id: 137,

--- a/spec/x402/chains_spec.rb
+++ b/spec/x402/chains_spec.rb
@@ -22,6 +22,27 @@ RSpec.describe X402, "chains" do
       )
     end
 
+    it "includes arbitrum mainnet configuration" do
+      expect(X402::CHAINS["arbitrum"]).to include(
+        chain_id: 42161,
+        usdc_address: "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
+        explorer_url: "https://arbiscan.io"
+      )
+    end
+
+    it "includes arbitrum-sepolia configuration" do
+      expect(X402::CHAINS["arbitrum-sepolia"]).to include(
+        chain_id: 421614,
+        usdc_address: "0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d",
+        explorer_url: "https://sepolia.arbiscan.io"
+      )
+    end
+
+    it "uses the on-chain USDC domain for arbitrum chains" do
+      expect(X402::CHAINS["arbitrum"][:currency]).to include(name: "USD Coin", version: "2")
+      expect(X402::CHAINS["arbitrum-sepolia"][:currency]).to include(name: "USD Coin", version: "2")
+    end
+
     it "includes avalanche-fuji configuration" do
       expect(X402::CHAINS["avalanche-fuji"]).to include(
         chain_id: 43113,
@@ -124,6 +145,11 @@ RSpec.describe X402, "chains" do
       expect(X402.usdc_address_for("polygon")).to eq("0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359")
     end
 
+    it "returns USDC address for arbitrum" do
+      expect(X402.usdc_address_for("arbitrum")).to eq("0xaf88d065e77c8cC2239327C5EDb3A432268e5831")
+      expect(X402.usdc_address_for("arbitrum-sepolia")).to eq("0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d")
+    end
+
     it "returns nil for unsupported chain" do
       expect(X402.usdc_address_for("ethereum")).to be_nil
     end
@@ -153,6 +179,8 @@ RSpec.describe X402, "chains" do
       expect(X402.to_caip2("base-sepolia")).to eq("eip155:84532")
       expect(X402.to_caip2("base")).to eq("eip155:8453")
       expect(X402.to_caip2("avalanche")).to eq("eip155:43114")
+      expect(X402.to_caip2("arbitrum")).to eq("eip155:42161")
+      expect(X402.to_caip2("arbitrum-sepolia")).to eq("eip155:421614")
     end
 
     it "converts custom chains to CAIP-2 format" do
@@ -175,6 +203,8 @@ RSpec.describe X402, "chains" do
       expect(X402.from_caip2("eip155:84532")).to eq("base-sepolia")
       expect(X402.from_caip2("eip155:8453")).to eq("base")
       expect(X402.from_caip2("eip155:43114")).to eq("avalanche")
+      expect(X402.from_caip2("eip155:42161")).to eq("arbitrum")
+      expect(X402.from_caip2("eip155:421614")).to eq("arbitrum-sepolia")
     end
 
     it "converts custom chain CAIP-2 format to chain name" do


### PR DESCRIPTION
## Summary

Adds Arbitrum One (`arbitrum`) and Arbitrum Sepolia (`arbitrum-sepolia`) to the built-in chain registry, following the [x402 + MPP announcement for Arbitrum](https://blog.arbitrum.io/x402-and-mpp-for-agentic-finance-on-arbitrum/). Both networks are supported by the Coinbase CDP facilitator.

## Chain details

| Network | Key | CAIP-2 | USDC |
| ------- | --- | ------ | ---- |
| Arbitrum One | `arbitrum` | `eip155:42161` | `0xaf88d065e77c8cC2239327C5EDb3A432268e5831` |
| Arbitrum Sepolia | `arbitrum-sepolia` | `eip155:421614` | `0x75faf114eafb1BDbe2F0316DF893fd58CE46AA4d` |

Both USDC contracts return `name() = "USD Coin"` and `version() = "2"` on-chain (verified via `eth_call` against public RPCs), so both entries use the existing `USDC_NAMED_USD_COIN_V2` currency constant. Values also match the [upstream x402 network support table](https://github.com/coinbase/x402/blob/main/docs/core-concepts/network-and-token-support.mdx).

## Changes

- `lib/x402/chains.rb`: new Arbitrum registry entries
- `spec/x402/chains_spec.rb`: registry, CAIP-2 round-trip, USDC address, and EIP-712 domain coverage
- `README.md`: network count 18 → 20, built-in list, and the custom-chain examples now use Optimism since Arbitrum is built in; existing `register_chain(name: "arbitrum")` configs keep working because custom registrations take precedence over built-ins
- `lib/generators/x402/install/templates/x402_initializer.rb`:  arbitrum options in the generated initializer
- `CHANGELOG.md`: entry under the unreleased 1.2.0 section

## Testing

`bundle exec rspec` — 266 examples, 0 failures, line coverage 100%.